### PR TITLE
update pgsqlstore by moving code from grafeas repo

### DIFF
--- a/go/v1beta1/storage/pgsqlstore.go
+++ b/go/v1beta1/storage/pgsqlstore.go
@@ -16,11 +16,14 @@ package storage
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"log"
 	"strconv"
 	"time"
+
+	"github.com/grafeas/grafeas/go/v1beta1/storage"
 
 	"github.com/fernet/fernet-go"
 	"github.com/golang/protobuf/proto"
@@ -37,62 +40,128 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// Config is the configuration for PostgreSQL store.
+// json tags are required because
+// config.ConvertGenericConfigToSpecificType internally uses json package.
+type Config struct {
+	Host string `json:"host"`
+	// DBName has to alrady exist and can be accessed by User.
+	DBName   string `json:"db_name"`
+	User     string `json:"user"`
+	Password string `json:"password"`
+	// Valid sslmodes: disable, allow, prefer, require, verify-ca, verify-full.
+	// See https://www.postgresql.org/docs/current/static/libpq-connect.html for details
+	SSLMode     string `json:"ssl_mode"`
+	SSLRootCert string `json:"ssl_root_cert"`
+	// PaginationKey is a 32-bit URL-safe base64 key used to encrypt pagination tokens.
+	// If one is not provided, it will be generated.
+	// Multiple grafeas instances in the same cluster need the same value,
+	// and the reason follows:
+	// A client sends all requests to a unified load balancer,
+	// but it can contain multiple Grafeas instances.
+	// Consequently, if they do not share the same pagination key,
+	// the encrypted page returned by one instance cannot be successfully decrypted by another instance.
+	// As a result, if requests are routed to different Grafeas instances, pagination will be broken.
+	PaginationKey string `json:"pagination_key"`
+}
+
+// PgSQLStore provides functionalities to use PostgreSQL DB as a data store.
 type PgSQLStore struct {
 	*sql.DB
 	paginationKey string
 }
 
-func NewPgSQLStore(config *config.PgSQLConfig) (*PgSQLStore, error) {
-	err := createDatabase(CreateSourceString(config.User, config.Password, config.Host, "postgres", config.SSLMode), config.DbName)
+// StorageTypeProvider creates and initializes a new grafeas v1beta1 storage compatible PgSQL store based on the specified config.
+func StorageTypeProvider(_ string, ci *config.StorageConfiguration) (*storage.Storage, error) {
+	var c Config
+	err := config.ConvertGenericConfigToSpecificType(ci, &c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert to PostgreSQL-specific config, err: %v", err)
+	}
+
+	s, err := NewPgSQLStore(&c)
 	if err != nil {
 		return nil, err
 	}
-	db, err := sql.Open("postgres", CreateSourceString(config.User, config.Password, config.Host, config.DbName, config.SSLMode))
-	if err != nil {
-		return nil, err
-	}
-	if db.Ping() != nil {
-		return nil, errors.New("database server is not alive")
-	}
-	if _, err := db.Exec(createTables); err != nil {
-		db.Close()
-		return nil, err
-	}
-	return &PgSQLStore{
-		DB:            db,
-		paginationKey: config.PaginationKey,
+
+	return &storage.Storage{
+		Ps: s,
+		Gs: s,
 	}, nil
 }
 
-func createDatabase(source, dbName string) error {
-	db, err := sql.Open("postgres", source)
-	if err != nil {
-		return err
+// NewPgSQLStore creates a new PgSQL store based on the passed-in config.
+func NewPgSQLStore(config *Config) (*PgSQLStore, error) {
+	return NewStoreWithCustomConnector(newDSNConnector(*config), config.PaginationKey)
+}
+
+// dsnConnector references the implementation of sql.dsnConnector.
+type dsnConnector struct {
+	dsn    string
+	driver driver.Driver
+}
+
+// newDSNConnector returns a connector which
+// simply parses the passed-in config into a DSN during initialization and reuses it forever.
+func newDSNConnector(conf Config) *dsnConnector {
+	connector := &dsnConnector{
+		dsn:    assembleDSN(conf),
+		driver: &pq.Driver{},
 	}
-	defer db.Close()
-	// Check if db exists
-	res, err := db.Exec(
-		fmt.Sprintf("SELECT * FROM pg_catalog.pg_database WHERE datname='%s'", dbName))
-	if err != nil {
-		return err
+	return connector
+}
+
+func assembleDSN(c Config) string {
+	dsn := fmt.Sprintf("host=%s dbname=%s user=%s password=%s sslmode=%s",
+		c.Host, c.DBName, c.User, c.Password, c.SSLMode,
+	)
+	if c.SSLRootCert != "" {
+		dsn = fmt.Sprintf("%s sslrootcert=%s", dsn, c.SSLRootCert)
 	}
-	rowCnt, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-	// Create database if it doesn't exist
-	if rowCnt == 0 {
-		_, err = db.Exec(fmt.Sprintf("CREATE DATABASE %s", dbName))
+	return dsn
+}
+
+func (c *dsnConnector) Connect(context.Context) (driver.Conn, error) {
+	return c.driver.Open(c.dsn)
+}
+
+func (c *dsnConnector) Driver() driver.Driver {
+	return c.driver
+}
+
+// NewStoreWithCustomConnector creates a new PgSQL store using the custom connector.
+func NewStoreWithCustomConnector(connector driver.Connector, paginationKey string) (*PgSQLStore, error) {
+	if paginationKey == "" {
+		log.Println("pagination key is empty, generating...")
+		var key fernet.Key
+		if err := key.Generate(); err != nil {
+			return nil, fmt.Errorf("failed to generate pagination key, %s", err)
+		}
+		paginationKey = key.Encode()
+	} else {
+		// Validate pagination key
+		_, err := fernet.DecodeKey(paginationKey)
 		if err != nil {
-			return err
+			return nil, errors.New("invalid pagination key; must be 256-bit URL-safe base64")
 		}
 	}
-	return nil
+	db := sql.OpenDB(connector)
+	if err := db.Ping(); err != nil {
+		return nil, fmt.Errorf("failed to ping the database server, err: %v", err)
+	}
+	if _, err := db.Exec(createTables); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to create tables, err: %v", err)
+	}
+	return &PgSQLStore{
+		DB:            db,
+		paginationKey: paginationKey,
+	}, nil
 }
 
 // CreateProject adds the specified project to the store
 func (pg *PgSQLStore) CreateProject(ctx context.Context, pID string, p *prpb.Project) (*prpb.Project, error) {
-	_, err := pg.DB.Exec(insertProject, name.FormatProject(pID))
+	_, err := pg.DB.ExecContext(ctx, insertProject, name.FormatProject(pID))
 	if err, ok := err.(*pq.Error); ok {
 		// Check for unique_violation
 		if err.Code == "23505" {
@@ -107,7 +176,7 @@ func (pg *PgSQLStore) CreateProject(ctx context.Context, pID string, p *prpb.Pro
 // DeleteProject deletes the project with the given pID from the store
 func (pg *PgSQLStore) DeleteProject(ctx context.Context, pID string) error {
 	pName := name.FormatProject(pID)
-	result, err := pg.DB.Exec(deleteProject, pName)
+	result, err := pg.DB.ExecContext(ctx, deleteProject, pName)
 	if err != nil {
 		return status.Error(codes.Internal, "Failed to delete Project from database")
 	}
@@ -125,7 +194,7 @@ func (pg *PgSQLStore) DeleteProject(ctx context.Context, pID string) error {
 func (pg *PgSQLStore) GetProject(ctx context.Context, pID string) (*prpb.Project, error) {
 	pName := name.FormatProject(pID)
 	var exists bool
-	err := pg.DB.QueryRow(projectExists, pName).Scan(&exists)
+	err := pg.DB.QueryRowContext(ctx, projectExists, pName).Scan(&exists)
 	if err != nil {
 		return nil, status.Error(codes.Internal, "Failed to query Project from database")
 	}
@@ -138,6 +207,11 @@ func (pg *PgSQLStore) GetProject(ctx context.Context, pID string) (*prpb.Project
 // ListProjects returns up to pageSize number of projects beginning at pageToken (or from
 // start if pageToken is the empty string).
 func (pg *PgSQLStore) ListProjects(ctx context.Context, filter string, pageSize int, pageToken string) ([]*prpb.Project, string, error) {
+	count, err := pg.count(ctx, projectCount)
+	if err != nil {
+		return nil, "", status.Error(codes.Internal, "Failed to count Projects from database")
+	}
+
 	var filterQuery string
 	if filter != "" {
 		var fs FilterSQL
@@ -147,14 +221,9 @@ func (pg *PgSQLStore) ListProjects(ctx context.Context, filter string, pageSize 
 	query := fmt.Sprint(listProjects, filterQuery)
 	var rows *sql.Rows
 	id := decryptInt64(pageToken, pg.paginationKey, 0)
-	rows, err := pg.DB.QueryContext(ctx, query, id, pageSize)
+	rows, err = pg.DB.QueryContext(ctx, query, id, pageSize)
 	if err != nil {
 		return nil, "", status.Error(codes.Internal, "Failed to list Projects from database")
-	}
-
-	count, err := pg.count(projectCount)
-	if err != nil {
-		return nil, "", status.Error(codes.Internal, "Failed to count Projects from database")
 	}
 	var projects []*prpb.Project
 	var lastID int64
@@ -194,7 +263,7 @@ func (pg *PgSQLStore) CreateOccurrence(ctx context.Context, pID, uID string, o *
 		log.Printf("Invalid note name: %v", o.NoteName)
 		return nil, status.Error(codes.InvalidArgument, "Invalid note name")
 	}
-	_, err = pg.DB.Exec(insertOccurrence, pID, id, nPID, nID, proto.MarshalTextString(o))
+	_, err = pg.DB.ExecContext(ctx, insertOccurrence, pID, id, nPID, nID, proto.MarshalTextString(o))
 	if err, ok := err.(*pq.Error); ok {
 		// Check for unique_violation
 		if err.Code == "23505" {
@@ -206,7 +275,7 @@ func (pg *PgSQLStore) CreateOccurrence(ctx context.Context, pID, uID string, o *
 	return o, nil
 }
 
-// BatchCreateOccurrence batch creates the specified occurrences in PostreSQL.
+// BatchCreateOccurrences batch creates the specified occurrences in PostreSQL.
 func (pg *PgSQLStore) BatchCreateOccurrences(ctx context.Context, pID string, uID string, occs []*pb.Occurrence) ([]*pb.Occurrence, []error) {
 	clonedOccs := []*pb.Occurrence{}
 	for _, o := range occs {
@@ -231,7 +300,7 @@ func (pg *PgSQLStore) BatchCreateOccurrences(ctx context.Context, pID string, uI
 
 // DeleteOccurrence deletes the occurrence with the given pID and oID
 func (pg *PgSQLStore) DeleteOccurrence(ctx context.Context, pID, oID string) error {
-	result, err := pg.DB.Exec(deleteOccurrence, pID, oID)
+	result, err := pg.DB.ExecContext(ctx, deleteOccurrence, pID, oID)
 	if err != nil {
 		return status.Error(codes.Internal, "Failed to delete Occurrence from database")
 	}
@@ -251,7 +320,7 @@ func (pg *PgSQLStore) UpdateOccurrence(ctx context.Context, pID, oID string, o *
 	// TODO(#312): implement the update operation
 	o.UpdateTime = ptypes.TimestampNow()
 
-	result, err := pg.DB.Exec(updateOccurrence, pID, oID, proto.MarshalTextString(o))
+	result, err := pg.DB.ExecContext(ctx, updateOccurrence, proto.MarshalTextString(o), pID, oID)
 	if err != nil {
 		return nil, status.Error(codes.Internal, "Failed to update Occurrence")
 	}
@@ -268,7 +337,7 @@ func (pg *PgSQLStore) UpdateOccurrence(ctx context.Context, pID, oID string, o *
 // GetOccurrence returns the occurrence with pID and oID
 func (pg *PgSQLStore) GetOccurrence(ctx context.Context, pID, oID string) (*pb.Occurrence, error) {
 	var data string
-	err := pg.DB.QueryRow(searchOccurrence, pID, oID).Scan(&data)
+	err := pg.DB.QueryRowContext(ctx, searchOccurrence, pID, oID).Scan(&data)
 	switch {
 	case err == sql.ErrNoRows:
 		return nil, status.Errorf(codes.NotFound, "Occurrence with name %q/%q does not Exist", pID, oID)
@@ -287,6 +356,11 @@ func (pg *PgSQLStore) GetOccurrence(ctx context.Context, pID, oID string) (*pb.O
 // ListOccurrences returns up to pageSize number of occurrences for this project beginning
 // at pageToken, or from start if pageToken is the empty string.
 func (pg *PgSQLStore) ListOccurrences(ctx context.Context, pID, filter, pageToken string, pageSize int32) ([]*pb.Occurrence, string, error) {
+	count, err := pg.count(ctx, occurrenceCount, pID)
+	if err != nil {
+		return nil, "", status.Error(codes.Internal, "Failed to count Occurrences from database")
+	}
+
 	var filterQuery string
 	if filter != "" {
 		var fs FilterSQL
@@ -296,20 +370,16 @@ func (pg *PgSQLStore) ListOccurrences(ctx context.Context, pID, filter, pageToke
 	query := fmt.Sprint(listOccurrences, filterQuery)
 	var rows *sql.Rows
 	id := decryptInt64(pageToken, pg.paginationKey, 0)
-	rows, err := pg.DB.QueryContext(ctx, query, pID, id, pageSize)
+	rows, err = pg.DB.QueryContext(ctx, query, pID, id, pageSize)
 	if err != nil {
 		return nil, "", status.Error(codes.Internal, "Failed to list Occurrences from database")
 	}
 
-	count, err := pg.count(occurrenceCount, pID)
-	if err != nil {
-		return nil, "", status.Error(codes.Internal, "Failed to count Occurrences from database")
-	}
 	var os []*pb.Occurrence
-	var lastId int64
+	var lastID int64
 	for rows.Next() {
 		var data string
-		err := rows.Scan(&lastId, &data)
+		err := rows.Scan(&lastID, &data)
 		if err != nil {
 			return nil, "", status.Error(codes.Internal, "Failed to scan Occurrences row")
 		}
@@ -319,10 +389,10 @@ func (pg *PgSQLStore) ListOccurrences(ctx context.Context, pID, filter, pageToke
 		}
 		os = append(os, &o)
 	}
-	if count == lastId {
+	if count == lastID {
 		return os, "", nil
 	}
-	encryptedPage, err := encryptInt64(lastId, pg.paginationKey)
+	encryptedPage, err := encryptInt64(lastID, pg.paginationKey)
 	if err != nil {
 		return nil, "", status.Error(codes.Internal, "Failed to paginate projects")
 	}
@@ -336,7 +406,7 @@ func (pg *PgSQLStore) CreateNote(ctx context.Context, pID, nID, uID string, n *p
 	n.Name = nName
 	n.CreateTime = ptypes.TimestampNow()
 
-	_, err := pg.DB.Exec(insertNote, pID, nID, proto.MarshalTextString(n))
+	_, err := pg.DB.ExecContext(ctx, insertNote, pID, nID, proto.MarshalTextString(n))
 	if err, ok := err.(*pq.Error); ok {
 		// Check for unique_violation
 		if err.Code == "23505" {
@@ -374,7 +444,7 @@ func (pg *PgSQLStore) BatchCreateNotes(ctx context.Context, pID, uID string, not
 
 // DeleteNote deletes the note with the given pID and nID
 func (pg *PgSQLStore) DeleteNote(ctx context.Context, pID, nID string) error {
-	result, err := pg.DB.Exec(deleteNote, pID, nID)
+	result, err := pg.DB.ExecContext(ctx, deleteNote, pID, nID)
 	if err != nil {
 		return status.Error(codes.Internal, "Failed to delete Note from database")
 	}
@@ -396,7 +466,7 @@ func (pg *PgSQLStore) UpdateNote(ctx context.Context, pID, nID string, n *pb.Not
 	// TODO(#312): implement the update operation
 	n.UpdateTime = ptypes.TimestampNow()
 
-	result, err := pg.DB.Exec(updateNote, pID, nID, proto.MarshalTextString(n))
+	result, err := pg.DB.ExecContext(ctx, updateNote, proto.MarshalTextString(n), pID, nID)
 	if err != nil {
 		return nil, status.Error(codes.Internal, "Failed to update Note")
 	}
@@ -413,7 +483,7 @@ func (pg *PgSQLStore) UpdateNote(ctx context.Context, pID, nID string, n *pb.Not
 // GetNote returns the note with project (pID) and note ID (nID)
 func (pg *PgSQLStore) GetNote(ctx context.Context, pID, nID string) (*pb.Note, error) {
 	var data string
-	err := pg.DB.QueryRow(searchNote, pID, nID).Scan(&data)
+	err := pg.DB.QueryRowContext(ctx, searchNote, pID, nID).Scan(&data)
 	switch {
 	case err == sql.ErrNoRows:
 		return nil, status.Errorf(codes.NotFound, "Note with name %q/%q does not Exist", pID, nID)
@@ -452,6 +522,11 @@ func (pg *PgSQLStore) GetOccurrenceNote(ctx context.Context, pID, oID string) (*
 // ListNotes returns up to pageSize number of notes for this project (pID) beginning
 // at pageToken (or from start if pageToken is the empty string).
 func (pg *PgSQLStore) ListNotes(ctx context.Context, pID, filter, pageToken string, pageSize int32) ([]*pb.Note, string, error) {
+	count, err := pg.count(ctx, noteCount, pID)
+	if err != nil {
+		return nil, "", status.Error(codes.Internal, "Failed to count Notes from database")
+	}
+
 	var filterQuery string
 	if filter != "" {
 		var fs FilterSQL
@@ -465,15 +540,11 @@ func (pg *PgSQLStore) ListNotes(ctx context.Context, pID, filter, pageToken stri
 		return nil, "", status.Error(codes.Internal, "Failed to list Notes from database")
 	}
 
-	count, err := pg.count(noteCount, pID)
-	if err != nil {
-		return nil, "", status.Error(codes.Internal, "Failed to count Notes from database")
-	}
 	var ns []*pb.Note
-	var lastId int64
+	var lastID int64
 	for rows.Next() {
 		var data string
-		err := rows.Scan(&lastId, &data)
+		err := rows.Scan(&lastID, &data)
 		if err != nil {
 			return nil, "", status.Error(codes.Internal, "Failed to scan Notes row")
 		}
@@ -483,10 +554,10 @@ func (pg *PgSQLStore) ListNotes(ctx context.Context, pID, filter, pageToken stri
 		}
 		ns = append(ns, &n)
 	}
-	if count == lastId {
+	if count == lastID {
 		return ns, "", nil
 	}
-	encryptedPage, err := encryptInt64(lastId, pg.paginationKey)
+	encryptedPage, err := encryptInt64(lastID, pg.paginationKey)
 	if err != nil {
 		return nil, "", status.Error(codes.Internal, "Failed to paginate projects")
 	}
@@ -500,21 +571,21 @@ func (pg *PgSQLStore) ListNoteOccurrences(ctx context.Context, pID, nID, filter,
 	if _, err := pg.GetNote(ctx, pID, nID); err != nil {
 		return nil, "", err
 	}
-	var rows *sql.Rows
-	id := decryptInt64(pageToken, pg.paginationKey, 0)
-	rows, err := pg.DB.Query(listNoteOccurrences, pID, nID, id, pageSize)
-	if err != nil {
-		return nil, "", status.Error(codes.Internal, "Failed to list Occurrences from database")
-	}
-	count, err := pg.count(noteOccurrencesCount, pID, nID)
+	count, err := pg.count(ctx, noteOccurrencesCount, pID, nID)
 	if err != nil {
 		return nil, "", status.Error(codes.Internal, "Failed to count Occurrences from database")
 	}
+	id := decryptInt64(pageToken, pg.paginationKey, 0)
+	rows, err := pg.DB.QueryContext(ctx, listNoteOccurrences, pID, nID, id, pageSize)
+	if err != nil {
+		return nil, "", status.Error(codes.Internal, "Failed to list Occurrences from database")
+	}
+
 	var os []*pb.Occurrence
-	var lastId int64
+	var lastID int64
 	for rows.Next() {
 		var data string
-		err := rows.Scan(&lastId, &data)
+		err := rows.Scan(&lastID, &data)
 		if err != nil {
 			return nil, "", status.Error(codes.Internal, "Failed to scan Occurrences row")
 		}
@@ -524,10 +595,10 @@ func (pg *PgSQLStore) ListNoteOccurrences(ctx context.Context, pID, nID, filter,
 		}
 		os = append(os, &o)
 	}
-	if count == lastId {
+	if count == lastID {
 		return os, "", nil
 	}
-	encryptedPage, err := encryptInt64(lastId, pg.paginationKey)
+	encryptedPage, err := encryptInt64(lastID, pg.paginationKey)
 	if err != nil {
 		return nil, "", status.Error(codes.Internal, "Failed to paginate projects")
 	}
@@ -548,8 +619,8 @@ func CreateSourceString(user, password, host, dbName, SSLMode string) string {
 }
 
 // count returns the total number of entries for the specified query (assuming SELECT(*) is used)
-func (pg *PgSQLStore) count(query string, args ...interface{}) (int64, error) {
-	row := pg.DB.QueryRow(query, args...)
+func (pg *PgSQLStore) count(ctx context.Context, query string, args ...interface{}) (int64, error) {
+	row := pg.DB.QueryRowContext(ctx, query, args...)
 	var count int64
 	err := row.Scan(&count)
 	if err != nil {

--- a/go/v1beta1/storage/pgsqlstore.go
+++ b/go/v1beta1/storage/pgsqlstore.go
@@ -23,14 +23,13 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/grafeas/grafeas/go/v1beta1/storage"
-
 	"github.com/fernet/fernet-go"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/uuid"
 	"github.com/grafeas/grafeas/go/config"
 	"github.com/grafeas/grafeas/go/name"
+	"github.com/grafeas/grafeas/go/v1beta1/storage"
 	pb "github.com/grafeas/grafeas/proto/v1beta1/grafeas_go_proto"
 	prpb "github.com/grafeas/grafeas/proto/v1beta1/project_go_proto"
 	"github.com/lib/pq"

--- a/go/v1beta1/storage/pgsqlstore_test.go
+++ b/go/v1beta1/storage/pgsqlstore_test.go
@@ -1,22 +1,17 @@
-// Copyright 2019 The Grafeas Authors. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package storage
 
 import (
 	"database/sql"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
 	"testing"
 
 	"github.com/grafeas/grafeas/go/config"
@@ -25,17 +20,173 @@ import (
 	"github.com/grafeas/grafeas/go/v1beta1/storage"
 )
 
+const (
+	pid           = "pid"
+	nid           = "nid"
+	paginationKey = "nQi0NzMjerFtlMnbylnWzMrIlNCsuyzeq8LnBEkgxrk=" // go get -v github.com/fernet/fernet-go/cmd/fernet-keygen ; fernet-keygen
+)
+
 type testPgHelper struct {
 	pgDataPath string
 	pgBinPath  string
 	startedPg  bool
-	pgConfig   *config.PgSQLConfig
+	pgConfig   *Config
 }
 
 var (
 	//Unfortunately, not a good way to pass this information around to tests except via a globally scoped var
 	pgsqlstoreTestPgConfig *testPgHelper
 )
+
+func startupPostgres(pgData *testPgHelper) error {
+	//Create a test database instance directory
+	if pgDataPath, err := ioutil.TempDir("", "pg-data-*"); err != nil {
+		return err
+	} else {
+		pgData.pgDataPath = filepath.ToSlash(pgDataPath)
+	}
+
+	//Make password file
+	passwordTempFile, err := ioutil.TempFile("", "pgpassword-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(passwordTempFile.Name())
+
+	if _, err = io.WriteString(passwordTempFile, pgData.pgConfig.Password); err != nil {
+		return err
+	}
+
+	if err := passwordTempFile.Sync(); err != nil {
+		return err
+	}
+
+	port, err := findAvailablePort()
+	if err != nil {
+		return err
+	}
+	pgData.pgConfig.Host = fmt.Sprintf("127.0.0.1:%d", port)
+
+	//Init db
+	pgCtl := filepath.Join(pgData.pgBinPath, "pg_ctl")
+	fmt.Fprintln(os.Stderr, "testing: intializing test postgres instance under", pgData.pgDataPath)
+	pgCtlInitDBOptions := fmt.Sprintf("--username %s --pwfile %s", pgData.pgConfig.User, passwordTempFile.Name())
+	cmd := exec.Command(pgCtl, "--pgdata", pgData.pgDataPath, "-o", pgCtlInitDBOptions, "initdb")
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	//Start postgres
+	fmt.Fprintln(os.Stderr, "testing: starting test postgres instance on port", port)
+	pgCtlStartOptions := fmt.Sprintf("-p %d", port)
+	cmd = exec.Command(pgCtl, "--pgdata", pgData.pgDataPath, "-o", pgCtlStartOptions, "start")
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	pgData.startedPg = true
+
+	return nil
+}
+
+func findAvailablePort() (availablePort int, err error) {
+	for availablePort = 5432; availablePort < 6000; availablePort++ {
+		l, err := net.Listen("tcp", fmt.Sprintf(":%d", availablePort))
+		l.Close()
+		if err == nil {
+			return availablePort, nil
+		}
+	}
+
+	return -1, fmt.Errorf("unable to find an open port")
+}
+
+func isPostgresRunning(config *Config) bool {
+	source := storage.CreateSourceString(config.User, config.Password, config.Host, "postgres", config.SSLMode)
+	db, err := sql.Open("postgres", source)
+	if err != nil {
+		return false
+	}
+	defer db.Close()
+
+	if db.Ping() != nil {
+		return false
+	}
+	return true
+}
+
+func getPostgresBinPathFromSystemPath() (binPath string, err error) {
+	cmd := exec.Command("which", "pg_ctl")
+	output, err := cmd.Output()
+	if output != nil && err == nil {
+		binPath = filepath.ToSlash(filepath.Dir(string(output)))
+	}
+
+	//Deal with "which" Linux-style output on Windows, a bit of a corner case
+	regex := regexp.MustCompile("^/([a-z])/(.*)$")
+	regexMatches := regex.FindStringSubmatch(binPath)
+	if runtime.GOOS == "windows" && regexMatches != nil && len(regexMatches) == 3 {
+		binPath = fmt.Sprintf("%s:/%s", regexMatches[1], regexMatches[2])
+	}
+
+	return
+}
+
+func setup() (pgData *testPgHelper, err error) {
+	pgConfig := &Config{
+		Host:     "127.0.0.1:5432",
+		User:     "postgres",
+		Password: "password",
+		SSLMode:  "disable",
+	}
+
+	pgData = &testPgHelper{
+		startedPg: false,
+		pgConfig:  pgConfig,
+	}
+
+	//See if postgres is already available and running
+	if isPostgresRunning(pgConfig) {
+		return
+	}
+
+	//Check for a global installation
+	if pgData.pgBinPath, err = getPostgresBinPathFromSystemPath(); err != nil {
+		err = fmt.Errorf("unable to find a running Postgres instance or Postgres binaries necessary for testing on the system PATH: %v", err)
+		return
+	}
+
+	//Startup postgres
+	if err = startupPostgres(pgData); err != nil {
+		return
+	}
+
+	return pgData, nil
+}
+
+func stopPostgres(pgData *testPgHelper) error {
+	if pgData != nil && pgData.startedPg {
+		//Stop postgres
+		pgCtl := filepath.Join(pgData.pgBinPath, "pg_ctl")
+
+		fmt.Fprintln(os.Stderr, "testing: stopping test postgres instance")
+		cmd := exec.Command(pgCtl, "--pgdata", pgData.pgDataPath, "stop")
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+
+		//Cleanup
+		if err := os.RemoveAll(pgData.pgDataPath); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func teardown(pgData *testPgHelper) error {
+	return stopPostgres(pgData)
+}
 
 func dropDatabase(t *testing.T, config *config.PgSQLConfig) {
 	t.Helper()
@@ -58,6 +209,23 @@ func dropDatabase(t *testing.T, config *config.PgSQLConfig) {
 	}
 }
 
+func TestMain(m *testing.M) {
+	var err error
+	pgsqlstoreTestPgConfig, err = setup()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	exitVal := m.Run()
+
+	if err := teardown(pgsqlstoreTestPgConfig); err != nil {
+		log.Fatal(err)
+	}
+
+	// os.Exit() does not respect defer statements
+	os.Exit(exitVal)
+}
+
 func TestBetaPgSQLStore(t *testing.T) {
 	createPgSQLStore := func(t *testing.T) (grafeas.Storage, project.Storage, func()) {
 		t.Helper()
@@ -69,7 +237,7 @@ func TestBetaPgSQLStore(t *testing.T) {
 			SSLMode:       pgsqlstoreTestPgConfig.pgConfig.SSLMode,
 			PaginationKey: "XxoPtCUzrUv4JV5dS+yQ+MdW7yLEJnRMwigVY/bpgtQ=",
 		}
-		pg, err := NewPgSQLStore(config)
+		pg, err := storage.NewPgSQLStore(config)
 		if err != nil {
 			t.Errorf("Error creating PgSQLStore, %s", err)
 		}
@@ -85,22 +253,67 @@ func TestPgSQLStoreWithUserAsEnv(t *testing.T) {
 	createPgSQLStore := func(t *testing.T) (grafeas.Storage, project.Storage, func()) {
 		t.Helper()
 		config := &config.PgSQLConfig{
-			Host:          "127.0.0.1:5432",
+			Host:          pgsqlstoreTestPgConfig.pgConfig.Host,
 			DbName:        "test_db",
 			User:          "",
 			Password:      "",
-			SSLMode:       "disable",
+			SSLMode:       pgsqlstoreTestPgConfig.pgConfig.SSLMode,
 			PaginationKey: "XxoPtCUzrUv4JV5dS+yQ+MdW7yLEJnRMwigVY/bpgtQ=",
 		}
-		_ = os.Setenv("PGUSER", "postgres")
-		_ = os.Setenv("PGPASSWORD", "password")
+		_ = os.Setenv("PGUSER", pgsqlstoreTestPgConfig.pgConfig.User)
+		_ = os.Setenv("PGPASSWORD", pgsqlstoreTestPgConfig.pgConfig.Password)
 		pg, err := storage.NewPgSQLStore(config)
 		if err != nil {
-			t.Errorf("Error creating PgSQLStore: %v", err)
+			t.Errorf("Error creating PgSQLStore, %s", err)
 		}
 		var g grafeas.Storage = pg
 		var gp project.Storage = pg
 		return g, gp, func() { dropDatabase(t, config); pg.Close() }
 	}
+
 	storage.DoTestStorage(t, createPgSQLStore)
+}
+
+func TestBetaPgSQLStoreWithNoPaginationKey(t *testing.T) {
+	createPgSQLStore := func(t *testing.T) (grafeas.Storage, project.Storage, func()) {
+		t.Helper()
+		config := &config.PgSQLConfig{
+			Host:          pgsqlstoreTestPgConfig.pgConfig.Host,
+			DbName:        "test_db",
+			User:          pgsqlstoreTestPgConfig.pgConfig.User,
+			Password:      pgsqlstoreTestPgConfig.pgConfig.Password,
+			SSLMode:       pgsqlstoreTestPgConfig.pgConfig.SSLMode,
+			PaginationKey: "",
+		}
+		pg, err := storage.NewPgSQLStore(config)
+		if err != nil {
+			t.Errorf("Error creating PgSQLStore, %s", err)
+		}
+		var g grafeas.Storage = pg
+		var gp project.Storage = pg
+		return g, gp, func() { dropDatabase(t, config); pg.Close() }
+	}
+
+	storage.DoTestStorage(t, createPgSQLStore)
+}
+
+func TestBetaPgSQLStoreWithInvalidPaginationKey(t *testing.T) {
+	config := &config.PgSQLConfig{
+		Host:          pgsqlstoreTestPgConfig.pgConfig.Host,
+		DbName:        "test_db",
+		User:          pgsqlstoreTestPgConfig.pgConfig.User,
+		Password:      pgsqlstoreTestPgConfig.pgConfig.Password,
+		SSLMode:       pgsqlstoreTestPgConfig.pgConfig.SSLMode,
+		PaginationKey: "INVALID_VALUE",
+	}
+	pg, err := storage.NewPgSQLStore(config)
+	if pg != nil {
+		pg.Close()
+	}
+	if err == nil {
+		t.Errorf("expected error for invalid pagination key; got none")
+	}
+	if err.Error() != "invalid pagination key; must be 256-bit URL-safe base64" {
+		t.Errorf("expected error message about invalid pagination key; got: %s", err.Error())
+	}
 }


### PR DESCRIPTION
This PR updates the pgsqlstore.go to incorporate changes from grafeas storage files. Once the PR has been approved & merged we can start cleaning up code changes in grafeas repo related to PgSQL.

We also introduce `dsnConnector` similar to what we have in sql.Database. It will help us in testing the database by using a mockDB.