### PR TITLE
add 'has' filter

### DIFF
--- a/go/v1beta1/storage/filter.go
+++ b/go/v1beta1/storage/filter.go
@@ -50,6 +50,8 @@ func (fs *FilterSQL) sqlFromCall(funcName string, args []*expr.Expr) string {
 		sqlOp = "OR"
 	case operators.Index:
 		sqlOp = "["
+	case operators.Has:
+		sqlOp = "like"
 	default:
 		sqlOp = ""
 	}
@@ -59,6 +61,8 @@ func (fs *FilterSQL) sqlFromCall(funcName string, args []*expr.Expr) string {
 	}
 	if sqlOp == "[" {
 		return fmt.Sprintf("%s[%s]", argNames[0], argNames[1])
+	} else if sqlOp == "like" {
+		return fmt.Sprintf("(%s %s %s)", argNames[0], sqlOp, formatLikeString(argNames[1]))
 	} else if sqlOp != "" {
 		return fmt.Sprintf("(%s %s %s)", argNames[0], sqlOp, argNames[1])
 	}
@@ -141,4 +145,8 @@ func (fs *FilterSQL) ParseFilter(filter string) string {
 	}
 	sql := fs.makeSQL(result.Expr)
 	return sql
+}
+
+func formatLikeString(argName string) string {
+	return "'%" + strings.Split(argName, "'")[1] + "%'"
 }


### PR DESCRIPTION
### **Context**

The current filtering feature lacks the use of the 'has' operator, making it impossible to search for substrings.

### **Description**

This PR implements the `has` filtering based on the `like` SQL operator. 
Filter expression example: 
`resource.name:"str"` to search for entries containing the substring "str" in the value of `resource.name`